### PR TITLE
Add Python 3 support for popping up the UAC when needs_admin is set

### DIFF
--- a/pyexebuilder/custom_py2exe_py3.py
+++ b/pyexebuilder/custom_py2exe_py3.py
@@ -4,13 +4,34 @@ from argparse import Namespace
 from distutils.dist import Distribution
 
 from py2exe.distutils_buildexe import py2exe as build_exe
-from py2exe.runtime import Target, Runtime
+from py2exe.runtime import Target, Runtime, RT_MANIFEST
 
-
-# Subclass Target to specify these executables require Administrator
-class AdminTarget(Target):
-    uac_info = "requireAdministrator"
-
+# Copied from http://docwiki.embarcadero.com/RADStudio/Sydney/en/Customizing_the_Windows_Application_Manifest_File
+runAsAdminManifest = '''\
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+ <dependency>
+   <dependentAssembly>
+     <assemblyIdentity
+       type="win32"
+       name="Microsoft.Windows.Common-Controls"
+       version="6.0.0.0"
+       publicKeyToken="6595b64144ccf1df"
+       language="*"
+       processorArchitecture="*"/>
+   </dependentAssembly>
+ </dependency>
+ <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+   <security>
+     <requestedPrivileges>
+       <requestedExecutionLevel
+         level="requireAdministrator"
+         uiAccess="false"/>
+       </requestedPrivileges>
+   </security>
+ </trustInfo>
+</assembly>
+'''
 
 class _custom_Runtime(Runtime):
     def __init__(self, exe_builder, *args, **kwargs):
@@ -36,9 +57,10 @@ class custom_py2exe(build_exe):
         self.exe_builder = exe_builder
 
     def build_exe(self):
-        target_class = AdminTarget if self.exe_builder.needs_admin else Target
         try:
             args = {}
+            if self.exe_builder.needs_admin:
+                args['other_resources'] = [(RT_MANIFEST, 1, runAsAdminManifest)]
             if self.exe_builder.icon:
                 args['icon_resources'] = [(1, self.exe_builder.icon)]
             if self.exe_builder.script or self.exe_builder.module_name:
@@ -55,14 +77,14 @@ runpy.run_module(%r, run_name='__main__', alter_sys=True)
                 else:
                     script = self.exe_builder.script
                 exe_type = 'console_exe' if self.exe_builder.console else 'windows_exe'
-                target = target_class(script=script, exe_type=exe_type, **args)
+                target = Target(script=script, exe_type=exe_type, **args)
                 target.validate()
                 r = _custom_Runtime(self.exe_builder, self.get_options(self.exe_builder.dest_dir))
                 r.analyze()
                 exe_path = os.path.join(self.exe_builder.dest_dir, target.get_dest_base() + '.exe')
                 r.build_exe(target, exe_path, self.exe_builder.get_relative_lib_path())
             elif self.exe_builder.service_module:
-                target = target_class(
+                target = Target(
                     exe_type='service',
                     modules=[self.exe_builder.service_module],
                     cmdline_style='custom',

--- a/pyexebuilder/test/sample/helloworld_sleep.py
+++ b/pyexebuilder/test/sample/helloworld_sleep.py
@@ -1,0 +1,4 @@
+import time
+
+print("helloworld")
+time.sleep(10)

--- a/pyexebuilder/test/test_ExeBuilder.py
+++ b/pyexebuilder/test/test_ExeBuilder.py
@@ -32,24 +32,10 @@ def test_module_exe_name(tmp_folder):
     assert output.decode().rstrip() == "helloworld"
 
 
-def test_service_exe():
-    pytest.xfail("Not Implemented")
-
-
 def compile_check_ouput(tmp_folder, script_name):
     ExeBuilder(tmp_folder, script=os.path.join(os.path.dirname(__file__), 'sample', script_name + '.py')).build()
     output = subprocess.check_output(os.path.join(tmp_folder, script_name))
     return output.decode()
-
-
-@pytest.mark.xfail(reason="Not actually sure what the sys path should be")
-def test_syspath(tmp_folder):
-    assert compile_check_ouput(tmp_folder, "syspath").rstrip() == str(sys.path)
-
-
-@pytest.mark.xfail(run=False)
-def test_console():
-    pass
 
 
 def test_pywintypes(tmp_folder):

--- a/pyexebuilder/test/test_ExeBuilder_manually.py
+++ b/pyexebuilder/test/test_ExeBuilder_manually.py
@@ -1,0 +1,15 @@
+import os
+from tempfile import TemporaryDirectory
+
+
+# BEWARE this will import ExeBuilder from the pip installed package instead of
+# from the source tree. Always run `pip install .` before running this test
+from pyexebuilder.ExeBuilder import ExeBuilder
+
+
+if __name__ == '__main__':
+    with TemporaryDirectory() as tmp_folder:
+        ExeBuilder(tmp_folder, module_name="pyexebuilder.test.sample.helloworld_sleep", needs_admin=True).build()
+        file_name = os.path.join(tmp_folder, "helloworld_sleep.exe")
+        print("Manually run", file_name, "it should pop-up a UAC dialog and then print helloworld")
+        input("Hit enter when you are done")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages
 
 setup(
     name='py-exe-builder',
-    version='0.2.dev1',
+    version='0.2',
     packages = find_packages(),
     license='Apache License, Version 2.0',
     description='Uses py2exe to create small exe stubs that leverage a full python installation, rather than packing the required pyc files in to the executable.',


### PR DESCRIPTION
- Add Python 3 support for popping up the UAC when needs_admin is set
- Add a _manual_ test to check if this works. It's hard to automatically test if the UAC pops-up.
- Remove tests that aren't implemented. It's unlikely I was ever going to implement them and the existing tests give good coverage.
- Bump version to 0.2. After this PR, Python 3 has feature parity with Python 2, so we can make a release.